### PR TITLE
Feature: Enhance conflict handling for deletion errors (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the `MisRegistros-Back` project will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2025-09-21
+
+### Added
+
+- **Enhanced foreign key constraint error handling**: Implemented specific error handling for P2003 (Foreign Key Constraint) errors in Prisma middleware:
+  - Added dedicated handling for deletion conflicts when records have dependencies
+  - Improved HTTP status code from 400 Bad Request to 409 Conflict for better semantic accuracy
+  - Enhanced error messages with contextual information and actionable guidance
+
+### Changed
+
+- **Improved error response quality**:
+  - **Before**: Generic "Bad Request" with technical Prisma error details
+  - **After**: Clear "Conflict" message explaining the dependency issue and resolution steps
+
 ## [1.8.0] - 2025-09-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "misregistros-back",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "App to register all personal data",
   "main": "server.js",
   "scripts": {

--- a/src/shared/prisma/middlewares/error.codes.ts
+++ b/src/shared/prisma/middlewares/error.codes.ts
@@ -34,6 +34,16 @@ const ErrorCodes = (err: Error): ErrorWithCode => {
       result.response.error = "Conflict";
       result.response.details = "Unique constraint violation";
     }
+    if (err.code == "P2003") {
+      result.code = 409;
+      result.response.error = "Conflict";
+      if (err.message && err.message.includes("Cannot delete")) {
+        result.response.details = err.message;
+      } else {
+        result.response.details =
+          "Cannot delete this record because it is referenced by other records. Please remove the dependencies first.";
+      }
+    }
     if (err.code == "P2028" || err.code == "P5015") {
       result.code = 500;
       result.response.error = "Internal Server Error";


### PR DESCRIPTION
### 📋 Resumen

Se implementa manejo específico para errores de constraint de clave foránea (P2003) en el middleware de errores de Prisma. Anteriormente, cuando se intentaba eliminar un registro que tenía dependencias (como un ingrediente usado en recetas), se retornaba un error genérico de "Bad Request" con detalles técnicos poco claros. Ahora se proporciona un mensaje de error más descriptivo y un código de estado HTTP más apropiado (409 Conflict).

**Antes:**
```json
{
  "error": "Bad Request",
  "details": "Foreign key constraint failed on the field: `RecipeIngredient_idIngredient_fkey (index)` ..."
}
```

**Después:**
```json
{
  "error": "Conflict", 
  "details": "Cannot delete this record because it is referenced by other records. Please remove the dependencies first."
}
```
---

### 🧩 Tipo de cambio

- [ ] ✨ Feature (nueva funcionalidad)
- [X] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

### 🔗 Relacionado

- Issue: #76 

---