### PR TITLE
Feature: Add user avatar upload and deletion endpoints (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the `MisRegistros-Back` project will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-05-23
+
+### Added
+
+- **User avatar management**: Implemented profile picture upload and deletion for authenticated users:
+  - New field `avatar String?` on `User` model — migration `add_avatar_to_user`
+  - New `PATCH /v1/user/me/avatar` — accepts `multipart/form-data` with the file in the `avatar` field. Uploads to Cloudinary under `mis-registros/profile-pictures/`, converts to WebP. If the user already has an avatar, the previous image is deleted from Cloudinary automatically. Returns the updated `UserPublicModel`
+  - New `DELETE /v1/user/me/avatar` — removes the avatar from Cloudinary and sets `avatar: null` in DB. Returns `400` with message `"El usuario no tiene una foto de perfil"` if the user has no avatar set
+  - New `UserService.updateAvatar(userId, avatarUrl)` and `UserService.deleteAvatar(userId)` methods
+  - New `avatar?: string | null` field added to `UserModel` and `UserPublicModel` interfaces
+  - `avatar` field included in `select` of `register` and `getMe` service methods so all user endpoints return it consistently
+
+### Changed
+
+- **`uploadMiddleware`**: refactored from a fixed middleware to a factory function `uploadMiddleware(fieldName)` — allows each route to declare its own form field name. Recipe routes use `uploadMiddleware("thumbnail")`, avatar route uses `uploadMiddleware("avatar")`
+
 ## [1.11.0] - 2026-05-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "misregistros-back",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "misregistros-back",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "misregistros-back",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "App to register all personal data",
   "main": "server.js",
   "scripts": {

--- a/src/middleware/upload.middleware.ts
+++ b/src/middleware/upload.middleware.ts
@@ -24,32 +24,30 @@ const multerUpload = multer({
   limits: { fileSize: MAX_SIZE_MB * 1024 * 1024 },
 });
 
-const uploadMiddleware = (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): void => {
-  multerUpload.single("thumbnail")(req, res, (error) => {
-    if (!error) return next();
+const uploadMiddleware =
+  (fieldName: string) =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    multerUpload.single(fieldName)(req, res, (error) => {
+      if (!error) return next();
 
-    if (error instanceof MulterError && error.code === "LIMIT_FILE_SIZE") {
-      res.status(HttpStatusCode.BAD_REQUEST).json({
-        error: "Bad Request",
-        details: `El archivo no puede superar los ${MAX_SIZE_MB}MB`,
-      } satisfies ErrorResponse);
-      return;
-    }
+      if (error instanceof MulterError && error.code === "LIMIT_FILE_SIZE") {
+        res.status(HttpStatusCode.BAD_REQUEST).json({
+          error: "Bad Request",
+          details: `El archivo no puede superar los ${MAX_SIZE_MB}MB`,
+        } satisfies ErrorResponse);
+        return;
+      }
 
-    if (error instanceof Error && error.message === "INVALID_FILE_TYPE") {
-      res.status(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE).json({
-        error: "Unsupported Media Type",
-        details: "Solo se permiten imágenes en formato JPG, PNG o WebP",
-      } satisfies ErrorResponse);
-      return;
-    }
+      if (error instanceof Error && error.message === "INVALID_FILE_TYPE") {
+        res.status(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE).json({
+          error: "Unsupported Media Type",
+          details: "Solo se permiten imágenes en formato JPG, PNG o WebP",
+        } satisfies ErrorResponse);
+        return;
+      }
 
-    next(error);
-  });
-};
+      next(error);
+    });
+  };
 
 export default uploadMiddleware;

--- a/src/modules/recipeBook/routes/recipe.routes.ts
+++ b/src/modules/recipeBook/routes/recipe.routes.ts
@@ -29,7 +29,7 @@ export default class RecipeRouter {
       `/${this.version}/recipe`,
       AuthorizationApiKey,
       authMiddleware,
-      uploadMiddleware,
+      uploadMiddleware("thumbnail"),
       middlewareValidationSchema(RecipeCreateZodSchema),
       this.controller.create,
     );
@@ -46,7 +46,7 @@ export default class RecipeRouter {
       `/${this.version}/recipe/:id`,
       AuthorizationApiKey,
       authMiddleware,
-      uploadMiddleware,
+      uploadMiddleware("thumbnail"),
       middlewareValidationSchema(RecipeUpdateZodSchema),
       this.controller.patch,
     );

--- a/src/modules/user/controllers/user.controller.ts
+++ b/src/modules/user/controllers/user.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import UserService from "../services/user.service";
+import StorageService, { UploadResult } from "../../storage/services/storage.service";
 import LoggerService from "../../../services/logger";
 import ErrorCodes from "../../../shared/prisma/middlewares/error.codes";
 import {
@@ -10,6 +11,7 @@ import { HttpStatusCode } from "../../../shared/types.environment";
 import { AuthenticatedRequest } from "../../../middleware/auth.middleware";
 
 const userService = new UserService();
+const storageService = new StorageService();
 const logger = new LoggerService("User");
 
 export default class UserController {
@@ -152,6 +154,88 @@ export default class UserController {
         return res.status(HttpStatusCode.NOT_FOUND).send({
           error: "Not Found",
           details: "User not found",
+        } satisfies ErrorResponse);
+      }
+
+      const errorBody = ErrorCodes(
+        error instanceof Error ? error : new Error(message),
+      );
+      return res.status(errorBody.code).send(errorBody.response);
+    }
+  }
+
+  public async updateAvatar(
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<Response> {
+    let uploadResult: UploadResult | undefined;
+
+    try {
+      const idUser = req.user!.id;
+
+      if (!req.file) {
+        return res.status(HttpStatusCode.BAD_REQUEST).send({
+          error: "Bad Request",
+          details: "No se recibió ningún archivo",
+        } satisfies ErrorResponse);
+      }
+
+      const current = await userService.getMe(idUser);
+      const oldAvatarUrl = current.avatar ?? undefined;
+
+      uploadResult = await storageService.upload(
+        req.file.buffer,
+        "mis-registros/profile-pictures",
+      );
+
+      const user = await userService.updateAvatar(idUser, uploadResult.url);
+
+      if (oldAvatarUrl) {
+        const oldPublicId = storageService.extractPublicId(oldAvatarUrl);
+        if (oldPublicId) await storageService.delete(oldPublicId).catch(() => {});
+      }
+
+      logger.info("Avatar updated", { id: idUser });
+      const response: ItemResponse<typeof user> = { data: user };
+      return res.status(HttpStatusCode.OK).send(response);
+    } catch (error: unknown) {
+      if (uploadResult) {
+        await storageService.delete(uploadResult.public_id).catch(() => {});
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("Error while updating avatar", { error: message });
+
+      const errorBody = ErrorCodes(
+        error instanceof Error ? error : new Error(message),
+      );
+      return res.status(errorBody.code).send(errorBody.response);
+    }
+  }
+
+  public async deleteAvatar(
+    req: AuthenticatedRequest,
+    res: Response,
+  ): Promise<Response> {
+    try {
+      const idUser = req.user!.id;
+
+      const { oldAvatarUrl, user } = await userService.deleteAvatar(idUser);
+
+      const publicId = storageService.extractPublicId(oldAvatarUrl);
+      if (publicId) await storageService.delete(publicId).catch(() => {});
+
+      logger.info("Avatar deleted", { id: idUser });
+      const response: ItemResponse<typeof user> = { data: user };
+      return res.status(HttpStatusCode.OK).send(response);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("Error while deleting avatar", { error: message });
+
+      if (message === "NO_AVATAR") {
+        return res.status(HttpStatusCode.BAD_REQUEST).send({
+          error: "Bad Request",
+          details: "El usuario no tiene una foto de perfil",
         } satisfies ErrorResponse);
       }
 

--- a/src/modules/user/models/user.model.ts
+++ b/src/modules/user/models/user.model.ts
@@ -10,6 +10,7 @@ export interface UserModel extends BaseEntity {
   role: Role;
   isActive: boolean;
   lastLoginAt?: Date | null;
+  avatar?: string | null;
 }
 
 //~ Safe to expose (no passwordHash)
@@ -21,6 +22,7 @@ export interface UserPublicModel {
   isActive: boolean;
   lastLoginAt?: Date | null;
   createdAt?: Date;
+  avatar?: string | null;
 }
 
 export interface UserLoginResponse {

--- a/src/modules/user/routes/user.routes.ts
+++ b/src/modules/user/routes/user.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import AuthorizationApiKey from "../../../shared/prisma/middlewares/authorization";
 import authMiddleware from "../../../middleware/auth.middleware";
+import uploadMiddleware from "../../../middleware/upload.middleware";
 import middlewareValidationSchema from "../../../shared/zod/middleware/schema.validation";
 import {
   UserRegisterZodSchema,
@@ -53,6 +54,21 @@ export default class UserRouter {
       AuthorizationApiKey,
       authMiddleware,
       this.controller.getMe,
+    );
+
+    this.router.patch(
+      `/${this.version}/user/me/avatar`,
+      AuthorizationApiKey,
+      authMiddleware,
+      uploadMiddleware("avatar"),
+      this.controller.updateAvatar,
+    );
+
+    this.router.delete(
+      `/${this.version}/user/me/avatar`,
+      AuthorizationApiKey,
+      authMiddleware,
+      this.controller.deleteAvatar,
     );
   }
 }

--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -38,6 +38,7 @@ export default class UserService {
         isActive: true,
         lastLoginAt: true,
         createdAt: true,
+        avatar: true,
       },
     });
 
@@ -161,6 +162,7 @@ export default class UserService {
         isActive: true,
         lastLoginAt: true,
         createdAt: true,
+        avatar: true,
       },
     });
 
@@ -169,5 +171,63 @@ export default class UserService {
     }
 
     return user;
+  }
+
+  public async updateAvatar(
+    userId: number,
+    avatarUrl: string,
+    ctx?: Context,
+  ): Promise<UserPublicModel> {
+    const prisma = ctx?.prisma || prismaClient;
+
+    return prisma.user.update({
+      where: { id: userId },
+      data: { avatar: avatarUrl },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        role: true,
+        isActive: true,
+        lastLoginAt: true,
+        createdAt: true,
+        avatar: true,
+      },
+    });
+  }
+
+  public async deleteAvatar(
+    userId: number,
+    ctx?: Context,
+  ): Promise<{ oldAvatarUrl: string; user: UserPublicModel }> {
+    const prisma = ctx?.prisma || prismaClient;
+
+    const current = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { avatar: true },
+    });
+
+    if (!current?.avatar) {
+      throw new Error("NO_AVATAR");
+    }
+
+    const oldAvatarUrl = current.avatar;
+
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: { avatar: null },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        role: true,
+        isActive: true,
+        lastLoginAt: true,
+        createdAt: true,
+        avatar: true,
+      },
+    });
+
+    return { oldAvatarUrl, user };
   }
 }

--- a/src/shared/prisma/migrations/20260524011810_add_avatar_to_user/migration.sql
+++ b/src/shared/prisma/migrations/20260524011810_add_avatar_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "avatar" TEXT;

--- a/src/shared/prisma/schema.prisma
+++ b/src/shared/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   lastLoginAt           DateTime?
   resetToken            String?   @unique
   resetTokenExpires     DateTime?
+  avatar                String?
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 


### PR DESCRIPTION
## 📋 Resumen

Se implementó la gestión de "Foto de Perfil" para usuarios autenticados. Las imágenes se almacenan en **Cloudinary** bajo `mis-registros/profile-pictures/` y la `URL` se persiste en el nuevo campo `avatar` del modelo `User`.

---

### Cambios principales:
- **Migración de DB**: Nuevo campo `avatar String?` en el modelo `User` — migración `add_avatar_to_user`. `UserModel` y `UserPublicModel` actualizados para incluir `avatar?: string | null`. El campo se agregó al `select` de `register` y `getMe` para que todos los endpoints de usuario lo retornen de forma consistente
- **Refactor de `uploadMiddleware`**: Convertido de función fija a función de orden superior `uploadMiddleware(fieldName)`. Permite que cada ruta declare su propio nombre de campo en el `FormData`. Las rutas de `recipe` usan `uploadMiddleware("thumbnail")` y la ruta de `avatar` usa `uploadMiddleware("avatar")`
- **`UserService`**: Nuevos métodos `updateAvatar(userId, avatarUrl)` y `deleteAvatar(userId)`. El método `deleteAvatar` valida que el usuario tenga avatar antes de proceder y retorna `{ oldAvatarUrl, user }` para que el controlador pueda eliminar la imagen de **Cloudinary**
- **`PATCH /v1/user/me/avatar`**: Acepta `multipart/form-data` con el archivo en el campo `avatar`. Si el usuario ya tiene `avatar`, elimina el anterior de **Cloudinary** automáticamente. Si el guardado en DB falla, elimina la imagen recién subida
- **`DELETE /v1/user/me/avatar`**: Elimina la imagen de **Cloudinary** y setea `avatar: null` en DB. `Retorna 400` con mensaje "El usuario no tiene una foto de perfil" si el usuario no tiene `avatar` asignado

---

## 🧩 Tipo de cambio

- [X] ✨ Feature (nueva funcionalidad)
- [ ] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [X] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [ ] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

## 🔗 Relacionado

**Issues**:
- #101
  - #102
  - #103
  - #104
  - #105
  - #106

---

## 🗒️ Notas adicionales

- El campo `avatar` aparece como `null` en usuarios existentes antes de que suban una foto. El frontend debe manejar ese valor al renderizar el avatar
- Los endpoints requieren `Authorization: Bearer <token>`. Sin token retornan `401 Unauthorized`.

---