### PR TITLE
Chore: Update seeds and fix pnpm (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the `MisRegistros-Back` project will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.3] - 2026-05-24
+
+### Fixed
+
+- **Seed fails with `spawn ts-node ENOENT` under pnpm**: `ts-node` was only a transitive dependency of `ts-node-dev`. pnpm does not hoist transitive dependencies, so the `ts-node` binary was not available in PATH when Prisma ran the seed command. Fixed by adding `ts-node` as a direct `devDependency`
+
+### Changed
+
+- **Seed images migrated from imgur to Cloudinary**: all recipe thumbnail URLs and the admin user avatar now point to Cloudinary (`res.cloudinary.com/dp5rqmzzw`) to keep seed data consistent with the rest of the image storage strategy
+
+---
+
 ## [1.12.2] - 2026-05-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jest-mock-extended": "^3.0.7",
     "prisma": "5.7.0",
     "ts-jest": "^29.1.4",
+    "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "5.4.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "misregistros-back",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "App to register all personal data",
   "main": "server.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       ts-jest:
         specifier: ^29.1.4
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.4.5)))(typescript@5.4.5)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@25.8.0)(typescript@5.4.5)
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@25.8.0)(typescript@5.4.5)

--- a/src/shared/prisma/seeds/recipeBook/recipes.ts
+++ b/src/shared/prisma/seeds/recipeBook/recipes.ts
@@ -7,7 +7,8 @@ const dataRecipes = [
       "Fideos con salsa de tomate y carne, una deliciosa combinación de fideos N°77 acompañados de una salsa casera preparada con cebolla, zanahoria, carne molida y tomate. La carne se cocina lentamente junto con las verduras, creando una salsa robusta que realza el sabor de los fideos al dente. Perfecto para una comida reconfortante y satisfactoria.",
     category: "Almuerzo",
     origin: "Italiana",
-    thumbnail: "https://i.imgur.com/6HydxA5.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648512/mis-registros/recipes/l9ninndfaem1dyaurk6o.webp",
     score: Score.EXCELLENT,
     time: 45,
     servings: 4,
@@ -34,7 +35,8 @@ const dataRecipes = [
       "Clásicas empanadas rellenas de carne, preparadas con una masa crujiente y un relleno sabroso de carne picada, cebolla, aceitunas y huevo duro sazonados con comino y pimentón. Horneadas hasta dorar, estas empanadas son ideales como un tentempié o plato principal en cualquier ocasión.",
     category: "Snack",
     origin: "Argentina",
-    thumbnail: "https://i.imgur.com/2HrnIiK.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648532/mis-registros/recipes/gr6ogtuc4ikqkysc06pi.webp",
     score: Score.GOOD,
     time: 60,
     servings: 8,
@@ -62,7 +64,8 @@ const dataRecipes = [
       "Paella española con mariscos y chorizo, un plato tradicional que combina arroz con langostinos, calamar y chorizo español, aromatizado con ajo, cebolla y pimentón rojo. El azafrán y el caldo de pescado complementan los sabores, creando una paella con una textura perfecta y un sabor profundo que evoca la cocina mediterránea.",
     category: "Almuerzo",
     origin: "Española",
-    thumbnail: "https://i.imgur.com/aB8thnu.png",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648583/mis-registros/recipes/mqwj3vxp5txzylaexe1k.webp",
     score: Score.EXCELLENT,
     time: 90,
     servings: 6,
@@ -93,7 +96,8 @@ const dataRecipes = [
       "Ensalada clásica con aderezo cremoso, hecha con lechuga romana fresca, pollo asado, crujientes cubos de pan tostado y queso parmesano. El aderezo César se mezcla delicadamente para realzar el sabor de los ingredientes frescos, creando una ensalada ligera pero satisfactoria.",
     category: "Almuerzo",
     origin: "Americana",
-    thumbnail: "https://i.imgur.com/8k2dGZH.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648596/mis-registros/recipes/ib64gk7ygwnepchzcf5g.webp",
     score: Score.GREAT,
     time: 20,
     servings: 2,
@@ -119,7 +123,8 @@ const dataRecipes = [
       "Desayuno nutritivo con huevos, aguacate y tostadas, que incluye huevos cocinados al gusto, aguacate fresco en rodajas, tostadas crujientes y tomates cherry. Un plato equilibrado que proporciona energía para empezar el día, con un toque saludable y delicioso.",
     category: "Desayuno",
     origin: "Americana",
-    thumbnail: "https://i.imgur.com/rrQHbDE.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648607/mis-registros/recipes/b8wb6jkxmu2y666hx6ks.webp",
     score: Score.EXCELLENT,
     time: 25,
     servings: 2,
@@ -147,7 +152,8 @@ const dataRecipes = [
       "Cóctel peruano refrescante con pisco y limón, elaborado con una mezcla de pisco, jugo de limón fresco, jarabe de goma y clara de huevo. Servido con hielo y unas gotas de amargo de Angostura, este cóctel es un equilibrio perfecto entre dulce y ácido, ideal para celebrar o disfrutar en cualquier ocasión.",
     category: "Trago",
     origin: "Peruana",
-    thumbnail: "https://i.imgur.com/YRzKPa3.png",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648617/mis-registros/recipes/wjkcv2cpv6tawt7zc137.webp",
     score: Score.EXCELLENT,
     time: 10,
     servings: 1,
@@ -173,7 +179,8 @@ const dataRecipes = [
       "Cóctel mexicano con tequila blanco, triple sec y jugo de lima, adornado con una elegante rodaja de lima en el borde. Esta bebida refrescante se prepara agitando los ingredientes con hielo en una coctelera y se sirve con un toque de sal en el borde del vaso. Perfecta para disfrutar en cualquier ocasión con su equilibrio único entre dulzura y acidez.",
     category: "Trago",
     origin: "Mexicana",
-    thumbnail: "https://i.imgur.com/0E3eKjr.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648629/mis-registros/recipes/vvqelbbyubstuav30wya.webp",
     score: Score.GOOD,
     time: 10,
     servings: 1,
@@ -198,7 +205,8 @@ const dataRecipes = [
       "Snack de palomitas de maíz cubiertas de caramelo, una delicia dulce y crujiente. Las palomitas se mezclan con una mezcla de mantequilla derretida y azúcar que se carameliza delicadamente, luego se sazona con una pizca de sal para equilibrar los sabores. Ideal para una tarde de cine en casa o cualquier celebración informal.",
     category: "Snack",
     origin: "Americana",
-    thumbnail: "https://i.imgur.com/JMr2FRD.png",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648641/mis-registros/recipes/ivy53tacif3mdnflrmar.webp",
     score: Score.GREAT,
     time: 15,
     servings: 4,
@@ -222,7 +230,8 @@ const dataRecipes = [
       "Delicioso guacamole casero preparado con aguacates maduros, tomate, cebolla morada y cilantro fresco, todo sazonado con limón y sal. Se sirve con Tostitos crujientes para disfrutar como aperitivo o acompañamiento. La combinación de sabores frescos y la textura cremosa del guacamole hacen de este plato una opción siempre popular.",
     category: "Snack",
     origin: "Mexicana",
-    thumbnail: "https://i.imgur.com/EAPZNFy.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648654/mis-registros/recipes/phswdxquii3fseoovcjn.webp",
     score: Score.EXCELLENT,
     time: 20,
     servings: 4,
@@ -250,7 +259,8 @@ const dataRecipes = [
       "Pequeñas pizzas individuales con salsa de tomate, queso mozzarella derretido y rodajas de pepperoni, todo sobre panecillos de pizza crujientes. Horneadas hasta que el queso se derrite y la masa esté dorada, estas mini pizzas son perfectas para fiestas infantiles o como un rápido almuerzo satisfactorio.",
     category: "Snack",
     origin: "Italiana",
-    thumbnail: "https://i.imgur.com/ydZbnKS.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648666/mis-registros/recipes/ajuou0zsjn8um5iy7h9x.webp",
     score: Score.GOOD,
     time: 30,
     servings: 6,
@@ -276,7 +286,8 @@ const dataRecipes = [
       "Ensalada fresca de atún con lechuga crujiente, pepino, pimentón rojo y huevo cocido, todo mezclado en un tazón. Perfecta para una comida ligera y nutritiva, esta ensalada se prepara con ingredientes simples pero sabrosos que se combinan a la perfección.",
     category: "Almuerzo",
     origin: "Americana",
-    thumbnail: "https://i.imgur.com/AheT9aK.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648677/mis-registros/recipes/mptrpnujttrkce1is68y.webp",
     score: Score.GOOD,
     time: 20,
     servings: 2,
@@ -300,7 +311,8 @@ const dataRecipes = [
       "Arroz con pollo y verduras, una receta reconfortante donde el pollo se cocina con cebolla y zanahoria en aceite caliente, luego se mezcla con arroz y se cocina lentamente hasta que esté listo. Esta comida abundante se sirve con pollo tierno y arroz aromático, perfecta para una comida familiar satisfactoria.",
     category: "Almuerzo",
     origin: "Española",
-    thumbnail: "https://i.imgur.com/OkUvyUP.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648687/mis-registros/recipes/hiukwimemwpqp2wzs81i.webp",
     score: Score.GREAT,
     time: 45,
     servings: 4,
@@ -326,7 +338,8 @@ const dataRecipes = [
       "Deliciosa tarta de manzana con un toque de canela, preparada con rodajas finas de manzana sobre una base de masa de empanadas. Se espolvorea con azúcar y canela, se añaden trozos de mantequilla y se hornea hasta que la superficie esté dorada y las manzanas estén tiernas. Ideal para disfrutar como postre o acompañamiento.",
     category: "Postre",
     origin: "Americana",
-    thumbnail: "https://i.imgur.com/zHssjys.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648701/mis-registros/recipes/n9uip3sngyt4wlyyldvh.webp",
     score: Score.GOOD,
     time: 60,
     servings: 8,
@@ -351,7 +364,8 @@ const dataRecipes = [
       "Reconfortante sopa de verduras con fideos, preparada con cebolla, zanahoria, puerro y apio, todos sofritos en aceite caliente antes de añadir agua y cocinar a fuego lento. Se agregan fideos que se cocinan hasta alcanzar la textura deseada. Perfecta para días fríos o como plato reconfortante en cualquier momento.",
     category: "Cena",
     origin: "Alemana",
-    thumbnail: "https://i.imgur.com/wtX9KjX.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648710/mis-registros/recipes/tmy6kskwtbr2m0nobrhg.webp",
     score: Score.GOOD,
     time: 40,
     servings: 4,
@@ -377,7 +391,8 @@ const dataRecipes = [
       "Tarta de espinaca con queso, elaborada con espinacas y cebolla sofritas en aceite caliente, mezcladas con una preparación de harina, manteca y agua. Se hornea en un molde hasta que la masa esté dorada y la superficie de la tarta, con el relleno de espinacas y queso, esté deliciosamente gratinada.",
     category: "Cena",
     origin: "Francesa",
-    thumbnail: "https://i.imgur.com/CqmnLLo.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648721/mis-registros/recipes/ksfccleaniaizwl29ndq.webp",
     score: Score.GOOD,
     time: 50,
     servings: 6,
@@ -401,7 +416,8 @@ const dataRecipes = [
       "Sopa de lentejas nutritiva y sabrosa, preparada con cebolla, zanahoria, puerro y apio sofritos en aceite caliente, luego cocidos lentamente con agua hasta que las lentejas estén tiernas y el caldo espeso. Ideal para una comida completa y reconfortante, especialmente en días frescos.",
     category: "Cena",
     origin: "Española",
-    thumbnail: "https://i.imgur.com/G4OZdjB.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648732/mis-registros/recipes/pzont56igq3bbgel5mom.webp",
     score: Score.GOOD,
     time: 60,
     servings: 6,
@@ -427,7 +443,8 @@ const dataRecipes = [
       "Tarta de choclo con cebolla y queso, donde el choclo y la cebolla se sofríen en aceite caliente antes de ser combinados con una mezcla de harina, manteca y agua. La masa se hornea hasta dorar y se rellena con la mezcla de choclo, cebolla y queso, creando una combinación sabrosa y gratinada.",
     category: "Cena",
     origin: "Argentina",
-    thumbnail: "https://i.imgur.com/R3vVNGm.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648742/mis-registros/recipes/rih2yv3ce0eti9p78xre.webp",
     score: Score.GOOD,
     time: 50,
     servings: 6,
@@ -451,7 +468,8 @@ const dataRecipes = [
       "Sopa de arvejas reconfortante con verduras y arroz, preparada con cebolla, zanahoria, puerro y apio sofritos en aceite caliente, seguidos de agua, arvejas y arroz. Cocinada a fuego lento hasta que los ingredientes estén tiernos y el caldo haya desarrollado sabores profundos. Perfecta para una comida nutritiva y satisfactoria.",
     category: "Cena",
     origin: "Alemana",
-    thumbnail: "https://i.imgur.com/iPs3qKQ.jpeg",
+    thumbnail:
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648754/mis-registros/recipes/byvneq9fom0pgxxznn7c.webp",
     score: Score.GOOD,
     time: 45,
     servings: 4,

--- a/src/shared/prisma/seeds/user/index.ts
+++ b/src/shared/prisma/seeds/user/index.ts
@@ -21,6 +21,8 @@ export async function seedUsers() {
       username: adminUsername,
       password: adminPassword,
       role: "ADMIN" as const,
+      avatar:
+        "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779588686/mis-registros/profile-pictures/lzpwsrtpnkaxcwvlfxdu.webp",
     },
   ];
 
@@ -44,6 +46,7 @@ export async function seedUsers() {
         username: userData.username,
         passwordHash,
         role: userData.role,
+        avatar: userData.avatar,
       },
     });
 


### PR DESCRIPTION
## 📋 Resumen

Correcciones en el sistema de seeds de **Prisma**: se migran las imágenes de imgur a **Cloudinary** y se resuelve el error de ejecución de `seeds` con `pnpm`.

---

## 🧩 Tipo de cambio

- [ ] ✨ Feature (nueva funcionalidad)
- [X] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [X] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

## 🔗 Relacionado

- Issue: #110 

---

## 🗒️ Notas adicionales

- Las `URLs` de `thumbnails` de las `recipes` en el `seed` fueron migradas de **imgur** a **Cloudinary** para mantener consistencia con el resto del sistema de imágenes de la app.
- Se agrega el `avatar` del usuario `admin` en el `seed `usando una imagen de **Cloudinary**.
- Se agrega `ts-node` como dependencia directa en `devDependencies`. Al migrar a `pnpm`, las dependencias transitivas no quedan expuestas en el PATH, lo que causaba el error `spawn ts-node ENOENT` al ejecutar `prisma migrate reset`.

---