### PR TITLE
Feature/112 max length constraints to zod schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the `MisRegistros-Back` project will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.0] - 2026-05-29
+
+### Added
+
+- **Thumbnail cleanup on recipe deletion**: `DELETE /v1/recipe/:id` now removes the associated Cloudinary image when the recipe has a thumbnail. Uses fire-and-forget — a failed storage call is silently caught so it never blocks the database deletion
+
+### Changed
+
+- **Maximum length validations added to Zod schemas**: Added `.max()` constraints across all schemas to prevent oversized input and protect visual layout integrity:
+  - `category.name` → 30
+  - `origin.name` → 30
+  - `ingredient.name` → 50
+  - `feature.name` → 50, `feature.description` → 100
+  - `recipe.name` → 100, `recipe.description` → 500
+  - `step.instruction` → 500
+  - `user.password` and `user.newPassword` → 72 (bcrypt processes only the first 72 bytes)
+
+### Fixed
+
+- **Feature seeds missing `isActive`**: Feature seed entries now explicitly set `isActive: true`, matching the expected default state
+- **Recipe seed thumbnails**: Updated recipe thumbnail URLs in seeds to point to current Cloudinary paths
+
+---
+
 ## [1.12.4] - 2026-05-26
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the `MisRegistros-Back` project will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.4] - 2026-05-26
+
+### Removed
+
+- **Recipe duplication endpoint**: Removed `POST /v1/recipe/:id/duplicate` endpoint along with `RecipeService.duplicate()` and its associated tests. The original approach created an immediate copy of the recipe server-side, which did not match the intended UX. The replacement flow pre-fills the recipe creation form on the frontend with the existing recipe's data, letting the user review and edit before saving — no dedicated endpoint is needed for this.
+
+---
+
 ## [1.12.3] - 2026-05-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "misregistros-back",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "App to register all personal data",
   "main": "server.js",
   "scripts": {

--- a/src/modules/feature/schema/feature.schema.ts
+++ b/src/modules/feature/schema/feature.schema.ts
@@ -8,10 +8,12 @@ import {
 export const FeatureBaseZodSchema = z.object({
   name: z
     .string({ invalid_type_error: "El campo 'nombre' debe ser un texto" })
-    .min(1, "El campo 'nombre' no puede estar vacío"),
+    .min(1, "El campo 'nombre' no puede estar vacío")
+    .max(50, "El campo 'nombre' no puede superar los 50 caracteres"),
   description: z
     .string({ invalid_type_error: "El campo 'descripción' debe ser un texto" })
-    .min(1, "El campo 'descripción' no puede estar vacío"),
+    .min(1, "El campo 'descripción' no puede estar vacío")
+    .max(100, "El campo 'descripción' no puede superar los 100 caracteres"),
   isActive: z.coerce.boolean().default(true),
 });
 

--- a/src/modules/recipeBook/controllers/recipe.controller.ts
+++ b/src/modules/recipeBook/controllers/recipe.controller.ts
@@ -187,6 +187,12 @@ export default class RecipeController {
       const idUser = req.user?.role !== "ADMIN" ? req.user!.id : undefined;
 
       const recipe = await recipeService.delete(id, undefined, idUser);
+
+      if (recipe.thumbnail) {
+        const publicId = storageService.extractPublicId(recipe.thumbnail);
+        if (publicId) await storageService.delete(publicId).catch(() => {});
+      }
+
       logger.info("Deleted", { id: recipe.id });
 
       const response: DeleteResponse = { deleted: true, id: recipe.id! };

--- a/src/modules/recipeBook/schema/category.schema.ts
+++ b/src/modules/recipeBook/schema/category.schema.ts
@@ -8,7 +8,8 @@ import {
 export const CategoryBaseZodSchema = z.object({
   name: z
     .string({ invalid_type_error: "El campo 'nombre' debe ser un texto" })
-    .min(1, "El campo 'nombre' no puede estar vacío"),
+    .min(1, "El campo 'nombre' no puede estar vacío")
+    .max(30, "El campo 'nombre' no puede superar los 30 caracteres"),
 });
 
 //~ CRUD Zod Schemas

--- a/src/modules/recipeBook/schema/ingredient.schema.ts
+++ b/src/modules/recipeBook/schema/ingredient.schema.ts
@@ -10,7 +10,8 @@ import { UnitList } from "../../../shared/enums";
 export const IngredientBaseZodSchema = z.object({
   name: z
     .string({ invalid_type_error: "El campo 'nombre' debe ser un texto" })
-    .min(1, "El campo 'nombre' no puede estar vacío"),
+    .min(1, "El campo 'nombre' no puede estar vacío")
+    .max(50, "El campo 'nombre' no puede superar los 50 caracteres"),
   unit: z.nativeEnum(UnitList, {
     errorMap: () => {
       return {

--- a/src/modules/recipeBook/schema/origin.schema.ts
+++ b/src/modules/recipeBook/schema/origin.schema.ts
@@ -8,7 +8,8 @@ import {
 export const OriginBaseZodSchema = z.object({
   name: z
     .string({ invalid_type_error: "El campo 'nombre' debe ser un texto" })
-    .min(1, "El campo 'nombre' no puede estar vacío"),
+    .min(1, "El campo 'nombre' no puede estar vacío")
+    .max(30, "El campo 'nombre' no puede superar los 30 caracteres"),
 });
 
 //~ CRUD Zod Schemas

--- a/src/modules/recipeBook/schema/recipe.schema.ts
+++ b/src/modules/recipeBook/schema/recipe.schema.ts
@@ -16,10 +16,12 @@ export const RecipeBaseZodSchema = z.object({
     .positive("Ingrese una 'id' válida"),
   name: z
     .string({ invalid_type_error: "El campo 'nombre' debe ser un texto" })
-    .min(1, "El campo 'nombre' no puede estar vacío"),
+    .min(1, "El campo 'nombre' no puede estar vacío")
+    .max(100, "El campo 'nombre' no puede superar los 100 caracteres"),
   description: z
     .string({ invalid_type_error: "El campo 'descripción' debe ser un texto" })
-    .min(1, "El campo 'descripción' no puede estar vacío"),
+    .min(1, "El campo 'descripción' no puede estar vacío")
+    .max(500, "El campo 'descripción' no puede superar los 500 caracteres"),
   thumbnail: z
     .string()
     .url("El campo 'thumbnail' debe ser una URL válida")

--- a/src/modules/recipeBook/schema/step.schema.ts
+++ b/src/modules/recipeBook/schema/step.schema.ts
@@ -16,7 +16,8 @@ export const StepBaseZodSchema = z.object({
     .optional(),
   instruction: z
     .string({ invalid_type_error: "El campo 'instrucción' debe ser un texto" })
-    .min(1, "El campo 'instrucción' no puede estar vacío"),
+    .min(1, "El campo 'instrucción' no puede estar vacío")
+    .max(500, "El campo 'instrucción' no puede superar los 500 caracteres"),
 });
 
 //~ CRUD Zod Schemas

--- a/src/modules/user/schema/user.schema.ts
+++ b/src/modules/user/schema/user.schema.ts
@@ -11,7 +11,8 @@ export const UserRegisterZodSchema = z.object({
       .max(30, "El campo 'username' no puede superar los 30 caracteres"),
     password: z
       .string({ invalid_type_error: "El campo 'password' debe ser un texto" })
-      .min(8, "El campo 'password' debe tener al menos 8 caracteres"),
+      .min(8, "El campo 'password' debe tener al menos 8 caracteres")
+      .max(72, "El campo 'password' no puede superar los 72 caracteres"),
   }),
 });
 
@@ -41,6 +42,7 @@ export const UserResetPasswordZodSchema = z.object({
       .min(1, "El campo 'token' no puede estar vacío"),
     newPassword: z
       .string({ invalid_type_error: "El campo 'newPassword' debe ser un texto" })
-      .min(8, "El campo 'newPassword' debe tener al menos 8 caracteres"),
+      .min(8, "El campo 'newPassword' debe tener al menos 8 caracteres")
+      .max(72, "El campo 'newPassword' no puede superar los 72 caracteres"),
   }),
 });

--- a/src/shared/prisma/seeds/feature/features.ts
+++ b/src/shared/prisma/seeds/feature/features.ts
@@ -3,10 +3,12 @@ const dataFeatures = {
     {
       name: "Libro de Recetas",
       description: "Libro con las Recetas hechas y por realizar",
+      isActive: true,
     },
     {
       name: "Eventos",
       description: "Eventos importantes para recordar",
+      isActive: true,
     },
     {
       name: "Ideas para Desarrollar",

--- a/src/shared/prisma/seeds/recipeBook/recipes.ts
+++ b/src/shared/prisma/seeds/recipeBook/recipes.ts
@@ -8,7 +8,7 @@ const dataRecipes = [
     category: "Almuerzo",
     origin: "Italiana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648512/mis-registros/recipes/l9ninndfaem1dyaurk6o.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110144/mis-registros/recipes/qfrfdkxi17vhglqq0teb.webp",
     score: Score.EXCELLENT,
     time: 45,
     servings: 4,
@@ -36,7 +36,7 @@ const dataRecipes = [
     category: "Snack",
     origin: "Argentina",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648532/mis-registros/recipes/gr6ogtuc4ikqkysc06pi.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110183/mis-registros/recipes/cqasykec9ltnijus7se9.webp",
     score: Score.GOOD,
     time: 60,
     servings: 8,
@@ -65,7 +65,7 @@ const dataRecipes = [
     category: "Almuerzo",
     origin: "Española",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648583/mis-registros/recipes/mqwj3vxp5txzylaexe1k.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110198/mis-registros/recipes/pp7rfdj4wgjcbre3eyev.webp",
     score: Score.EXCELLENT,
     time: 90,
     servings: 6,
@@ -97,7 +97,7 @@ const dataRecipes = [
     category: "Almuerzo",
     origin: "Americana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648596/mis-registros/recipes/ib64gk7ygwnepchzcf5g.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110245/mis-registros/recipes/hmu5lgpdqqngtyrvyprf.webp",
     score: Score.GREAT,
     time: 20,
     servings: 2,
@@ -124,7 +124,7 @@ const dataRecipes = [
     category: "Desayuno",
     origin: "Americana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648607/mis-registros/recipes/b8wb6jkxmu2y666hx6ks.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110270/mis-registros/recipes/tgzkws3hb6br07fdow8q.webp",
     score: Score.EXCELLENT,
     time: 25,
     servings: 2,
@@ -153,7 +153,7 @@ const dataRecipes = [
     category: "Trago",
     origin: "Peruana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648617/mis-registros/recipes/wjkcv2cpv6tawt7zc137.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110285/mis-registros/recipes/uuhj05jzu0gcd517rfpf.webp",
     score: Score.EXCELLENT,
     time: 10,
     servings: 1,
@@ -180,7 +180,7 @@ const dataRecipes = [
     category: "Trago",
     origin: "Mexicana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648629/mis-registros/recipes/vvqelbbyubstuav30wya.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110310/mis-registros/recipes/loc3ozxys4nq04ikuybz.webp",
     score: Score.GOOD,
     time: 10,
     servings: 1,
@@ -206,7 +206,7 @@ const dataRecipes = [
     category: "Snack",
     origin: "Americana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648641/mis-registros/recipes/ivy53tacif3mdnflrmar.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110330/mis-registros/recipes/q9qimuxgouyydcdvslpf.webp",
     score: Score.GREAT,
     time: 15,
     servings: 4,
@@ -231,7 +231,7 @@ const dataRecipes = [
     category: "Snack",
     origin: "Mexicana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648654/mis-registros/recipes/phswdxquii3fseoovcjn.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110345/mis-registros/recipes/atwnph7c5fqve5udyvwh.webp",
     score: Score.EXCELLENT,
     time: 20,
     servings: 4,
@@ -260,7 +260,7 @@ const dataRecipes = [
     category: "Snack",
     origin: "Italiana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648666/mis-registros/recipes/ajuou0zsjn8um5iy7h9x.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110363/mis-registros/recipes/klgdike2eb3hkmgur70e.webp",
     score: Score.GOOD,
     time: 30,
     servings: 6,
@@ -287,7 +287,7 @@ const dataRecipes = [
     category: "Almuerzo",
     origin: "Americana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648677/mis-registros/recipes/mptrpnujttrkce1is68y.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110391/mis-registros/recipes/eimvzd2qgkpvfv3pw55a.webp",
     score: Score.GOOD,
     time: 20,
     servings: 2,
@@ -312,7 +312,7 @@ const dataRecipes = [
     category: "Almuerzo",
     origin: "Española",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648687/mis-registros/recipes/hiukwimemwpqp2wzs81i.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110404/mis-registros/recipes/adbgyihtnyntp8n8t6th.webp",
     score: Score.GREAT,
     time: 45,
     servings: 4,
@@ -339,7 +339,7 @@ const dataRecipes = [
     category: "Postre",
     origin: "Americana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648701/mis-registros/recipes/n9uip3sngyt4wlyyldvh.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110422/mis-registros/recipes/cmfl2qxeqihqv0gjzmlz.webp",
     score: Score.GOOD,
     time: 60,
     servings: 8,
@@ -365,7 +365,7 @@ const dataRecipes = [
     category: "Cena",
     origin: "Alemana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648710/mis-registros/recipes/tmy6kskwtbr2m0nobrhg.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110435/mis-registros/recipes/nbr5eslxabnfz2smhujw.webp",
     score: Score.GOOD,
     time: 40,
     servings: 4,
@@ -392,7 +392,7 @@ const dataRecipes = [
     category: "Cena",
     origin: "Francesa",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648721/mis-registros/recipes/ksfccleaniaizwl29ndq.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110461/mis-registros/recipes/ycim6hucfjmowfz7yexd.webp",
     score: Score.GOOD,
     time: 50,
     servings: 6,
@@ -417,7 +417,7 @@ const dataRecipes = [
     category: "Cena",
     origin: "Española",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648732/mis-registros/recipes/pzont56igq3bbgel5mom.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110474/mis-registros/recipes/yoie3ysnnrqxtgyadquo.webp",
     score: Score.GOOD,
     time: 60,
     servings: 6,
@@ -444,7 +444,7 @@ const dataRecipes = [
     category: "Cena",
     origin: "Argentina",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648742/mis-registros/recipes/rih2yv3ce0eti9p78xre.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110487/mis-registros/recipes/ua5pnhblheghigd9zifr.webp",
     score: Score.GOOD,
     time: 50,
     servings: 6,
@@ -469,7 +469,7 @@ const dataRecipes = [
     category: "Cena",
     origin: "Alemana",
     thumbnail:
-      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1779648754/mis-registros/recipes/byvneq9fom0pgxxznn7c.webp",
+      "https://res.cloudinary.com/dp5rqmzzw/image/upload/v1780110502/mis-registros/recipes/ohdojt3jkkmy6mf1ivmd.webp",
     score: Score.GOOD,
     time: 45,
     servings: 4,


### PR DESCRIPTION
## 📋 Resumen

Mejoras de validación en los **schemas Zod** y corrección en el flujo de eliminación de recetas: se limpia automáticamente el **thumbnail** asociado en **Cloudinary** al eliminar una receta.

---

## 🧩 Tipo de cambio

- [x] ✨ Feature (nueva funcionalidad)
- [x] 🐛 Bugfix (corrección de un bug)
- [ ] 🔥 Hotfix (urgente en producción)
- [ ] ♻️ Refactor (mejora interna, sin cambios funcionales)
- [ ] 📝 Docs (documentación solamente)
- [x] 🚧 Chore (tareas menores, mantenimiento)
- [ ] ✅ Test (nuevos tests o ajustes)

---

## 🔗 Relacionado

- Issue: #

---

## 🗒️ Notas adicionales

- Se agregan validaciones `.max()` en todos los `schemas Zod` del proyecto para prevenir input excesivo y proteger la integridad visual del frontend: `category.name` (30), `origin.name` (30), `ingredient.name` (50), `feature.name` (50), `feature.description` (100), `recipe.name` (100), `recipe.description` (500), `step.instruction` (500). En `user.password` y `user.newPassword` se limita a 72 caracteres, ya que `bcrypt` solo procesa los primeros 72 bytes.
- Al eliminar una receta, el endpoint `DELETE /v1/recipe/:id` ahora elimina el `thumbnail` asociado en **Cloudinary** si existe. La operación es *fire-and-forget*: un fallo en el `storage` no bloquea la eliminación en base de datos.
- Se corrigen los `seeds` de `features` para establecer `isActive: true` de forma explícita, y se actualizan las `URLs` de `thumbnails` de recetas a las rutas actuales de **Cloudinary**.

---
